### PR TITLE
Don't use ./. as example

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       src = lib.mkOption {
         type = lib.types.path;
         description = "A path to the directory containing your cabal or hpack file";
-        example = ./.;
+        example = "./.";
       };
 
       ghcVersion = lib.mkOption {


### PR DESCRIPTION
`./.` always is interpreted (as all nix paths are) as relative to the file that it's in. This means that after we convert it to a string it shows up as a nix store path in the module schemas. So I think we should use strings here.

If this gets accepted, I'll make the same change in the nodejs and rust modules.