### PR TITLE
Set default ghc version to `9.8`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
       ghcVersion = lib.mkOption {
         type = lib.types.enum ["9.10" "9.8" "9.6" "9.4" "9.2" "9.0"];
         description = "The major GHC version to use";
-        default = "9.10";
+        default = "9.8";
       };
 
       webServer = lib.mkOption {


### PR DESCRIPTION
I tried out the haskell module on a tiny hello world project that used `hpack`. This then tried to compile `hpack`, but that didn't build with `ghc-9.10` from `nixpkgs`. So I'm proposing to downgrade the default to `9.8` until we or `nixpkgs` figure this out.

Here's a repo where you can try and see the build failures, if interested: https://github.com/garnix-io/multi-module-template/pull/1.