### PR TITLE
Remove nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -6,76 +6,106 @@
 
     [Documentation](https://garnix.io/docs/modules/haskell) - [Source](https://github.com/garnix-io/haskell-module).
   '';
-  outputs = { self }: {
-    garnixModules.default = { pkgs, lib, config, ... }:
-    let
-      webServerSubmodule.options = {
-        command = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "The command to run to start the server in production.";
-            example = "server --port \"$PORT\"";
-          } // { name = "server command"; };
-
-        port = lib.mkOption {
-          type = lib.types.port;
-          description = "Port to forward incoming HTTP requests to. This port has to be opened by the server command. This also sets the PORT environment variable for the server command.";
-          example = 7000;
-          default = 7000;
-        };
-
-        path = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "URL path your Haskell server will be hosted on.";
-            default = "/";
-          } // { name = "API path"; };
-      };
-
-      haskellSubmodule.options = {
-        src = lib.mkOption
-          {
-            type = lib.types.path;
-            description = "A path to the directory containing your cabal or hpack (`package.yaml`) file.";
-            example = "./.";
-          } // { name = "source directory"; };
-
-        ghcVersion = lib.mkOption
-          {
-            type = lib.types.enum [ "9.10" "9.8" "9.6" "9.4" "9.2" "9.0" ];
-            description = "The major GHC version to use.";
-            default = "9.8";
-          } // { name = "GHC version"; };
-
-        webServer = lib.mkOption {
-          type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
-          description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
-          default = null;
-        };
-
-        devTools = lib.mkOption
-          {
-            type = lib.types.listOf lib.types.package;
-            description = "A list of packages make available in the devshell for this project (and `default` devshell). This is useful for things like LSPs, formatters, etc.";
-            default = [ ];
-          } // { name = "development tools"; };
-
-        buildDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
-          default = [ ];
-        };
-
-        runtimeDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
-          default = [ ];
-        };
-      };
-
-      ghcStr = ghc: "ghc${builtins.replaceStrings ["."] [""] ghc}";
-    in
+  outputs =
+    { self }:
     {
+      garnixModules.default =
+        {
+          pkgs,
+          lib,
+          config,
+          ...
+        }:
+        let
+          webServerSubmodule.options = {
+            command =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "The command to run to start the server in production.";
+                example = "server --port \"$PORT\"";
+              }
+              // {
+                name = "server command";
+              };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = "Port to forward incoming HTTP requests to. This port has to be opened by the server command. This also sets the PORT environment variable for the server command.";
+              example = 7000;
+              default = 7000;
+            };
+
+            path =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "URL path your Haskell server will be hosted on.";
+                default = "/";
+              }
+              // {
+                name = "API path";
+              };
+          };
+
+          haskellSubmodule.options = {
+            src =
+              lib.mkOption {
+                type = lib.types.path;
+                description = "A path to the directory containing your cabal or hpack (`package.yaml`) file.";
+                example = "./.";
+              }
+              // {
+                name = "source directory";
+              };
+
+            ghcVersion =
+              lib.mkOption {
+                type = lib.types.enum [
+                  "9.10"
+                  "9.8"
+                  "9.6"
+                  "9.4"
+                  "9.2"
+                  "9.0"
+                ];
+                description = "The major GHC version to use.";
+                default = "9.8";
+              }
+              // {
+                name = "GHC version";
+              };
+
+            webServer = lib.mkOption {
+              type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
+              description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
+              default = null;
+            };
+
+            devTools =
+              lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                description = "A list of packages make available in the devshell for this project (and `default` devshell). This is useful for things like LSPs, formatters, etc.";
+                default = [ ];
+              }
+              // {
+                name = "development tools";
+              };
+
+            buildDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
+              default = [ ];
+            };
+
+            runtimeDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
+              default = [ ];
+            };
+          };
+
+          ghcStr = ghc: "ghc${builtins.replaceStrings [ "." ] [ "" ] ghc}";
+        in
+        {
           options = {
             haskell = lib.mkOption {
               type = lib.types.attrsOf (lib.types.submodule haskellSubmodule);
@@ -83,44 +113,41 @@
             };
           };
 
-          config =
-            {
-              packages = builtins.mapAttrs
-                (name: projectConfig:
-                  pkgs.haskell.packages."${ghcStr projectConfig.ghcVersion}".callCabal2nix
-                    "haskell-${name}"
-                    projectConfig.src
-                    { }
-                )
-                config.haskell;
+          config = {
+            packages = builtins.mapAttrs (
+              name: projectConfig:
+              pkgs.haskell.packages."${ghcStr projectConfig.ghcVersion}".callCabal2nix "haskell-${name}"
+                projectConfig.src
+                { }
+            ) config.haskell;
 
-              devShells = builtins.mapAttrs
-                (name: projectConfig:
-                  let haskellPackages = pkgs.haskell.packages."${ghcStr projectConfig.ghcVersion}";
-                  in
-                  pkgs.mkShell {
-                    inputsFrom =
-                      [
-                        (haskellPackages.callCabal2nix "haskell-${name}" projectConfig.src { }).env
-                      ];
-                    buildInputs = [
-                      haskellPackages.cabal-install
-                      haskellPackages.hpack
-                    ];
-                  }
-                )
-                config.haskell;
+            devShells = builtins.mapAttrs (
+              name: projectConfig:
+              let
+                haskellPackages = pkgs.haskell.packages."${ghcStr projectConfig.ghcVersion}";
+              in
+              pkgs.mkShell {
+                inputsFrom = [
+                  (haskellPackages.callCabal2nix "haskell-${name}" projectConfig.src { }).env
+                ];
+                buildInputs = [
+                  haskellPackages.cabal-install
+                  haskellPackages.hpack
+                ];
+              }
+            ) config.haskell;
 
-              nixosConfigurations =
-                let
-                  hasAnyWebServer =
-                    builtins.any (projectConfig: projectConfig.webServer != null)
-                      (builtins.attrValues config.haskell);
-                in
-                lib.mkIf hasAnyWebServer {
-                  default =
-                    # Global NixOS configuration
-                    [{
+            nixosConfigurations =
+              let
+                hasAnyWebServer = builtins.any (projectConfig: projectConfig.webServer != null) (
+                  builtins.attrValues config.haskell
+                );
+              in
+              lib.mkIf hasAnyWebServer {
+                default =
+                  # Global NixOS configuration
+                  [
+                    {
                       services.nginx = {
                         enable = true;
                         recommendedProxySettings = true;
@@ -131,11 +158,14 @@
                       };
 
                       networking.firewall.allowedTCPPorts = [ 80 ];
-                    }]
-                    ++
-                    # Per project NixOS configuration
-                    (builtins.attrValues (builtins.mapAttrs
-                      (name: projectConfig: lib.mkIf (projectConfig.webServer != null) {
+                    }
+                  ]
+                  ++
+                  # Per project NixOS configuration
+                  (builtins.attrValues (
+                    builtins.mapAttrs (
+                      name: projectConfig:
+                      lib.mkIf (projectConfig.webServer != null) {
                         environment.systemPackages = projectConfig.runtimeDependencies;
 
                         systemd.services.${name} = {
@@ -147,19 +177,23 @@
                           serviceConfig = {
                             Type = "simple";
                             DynamicUser = true;
-                            ExecStart = lib.getExe (pkgs.writeShellApplication {
-                              name = "start-${name}";
-                              runtimeInputs = [ config.packages.${name} ] ++ projectConfig.runtimeDependencies;
-                              text = projectConfig.webServer.command;
-                            });
+                            ExecStart = lib.getExe (
+                              pkgs.writeShellApplication {
+                                name = "start-${name}";
+                                runtimeInputs = [ config.packages.${name} ] ++ projectConfig.runtimeDependencies;
+                                text = projectConfig.webServer.command;
+                              }
+                            );
                           };
                         };
 
-                        services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass = "http://localhost:${toString projectConfig.webServer.port}";
-                      })
-                      config.haskell));
-                };
-            };
+                        services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass =
+                          "http://localhost:${toString projectConfig.webServer.port}";
+                      }
+                    ) config.haskell
+                  ));
+              };
+          };
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,9 @@
 
     [Documentation](https://garnix.io/docs/modules/haskell) - [Source](https://github.com/garnix-io/haskell-module).
   '';
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-  outputs = { self, nixpkgs }:
+  outputs = { self }: {
+    garnixModules.default = { pkgs, lib, config, ... }:
     let
-      lib = nixpkgs.lib;
-
       webServerSubmodule.options = {
         command = lib.mkOption
           {
@@ -74,11 +72,10 @@
           default = [ ];
         };
       };
+
+      ghcStr = ghc: "ghc${builtins.replaceStrings ["."] [""] ghc}";
     in
     {
-      garnixModules.default = { pkgs, config, ... }:
-        let ghcStr = ghc: "ghc${builtins.replaceStrings ["."] [""] ghc}";
-        in {
           options = {
             haskell = lib.mkOption {
               type = lib.types.attrsOf (lib.types.submodule haskellSubmodule);


### PR DESCRIPTION
The `nixpkgs` dependency was only being used for library functions, and
these functions are only needed within `garnixModules.default` which
receives `lib` from `garnix-lib`. By removing the `nixpkgs` input we can
be assured that there is only one `nixpkgs` being used: the one passed
in from `garnix-lib`.